### PR TITLE
Implement async-runner-ch

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
-(defproject cc.qbits/checkmate "0.4.0"
+(defproject cc.qbits/checkmate "0.4.1"
   :description "Retry stuff until it passes or break"
-  :url "https://github.com/mpenet/checkmate"
+  :url "https://github.com/finity-ai/checkmate"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.1"]

--- a/src/clj/qbits/checkmate.clj
+++ b/src/clj/qbits/checkmate.clj
@@ -46,7 +46,7 @@
                    default-callbacks
                    opts)]
         (loop [delays delays]
-          (let [[status ret :as step] (attempt this f)]
+          (let [[status ret] (attempt this f)]
             (case status
               ::success (when success (success ret))
               ::error (let [[delay & delays] delays]
@@ -86,7 +86,7 @@
                    default-callbacks
                    opts)]
         (async/go-loop [delays delays]
-          (let [[status ret :as step] (attempt this f)]
+          (let [[status ret] (attempt this f)]
             (case status
               ::success (when success (success ret))
               ::error (let [[delay & delays] delays]


### PR DESCRIPTION
https://trello.com/c/a2ZCESrE/5046-fix-postgres-es-fb-sentry-issues-in-live

That's probably what delay-runner-ch should have been actually. Should we keep it?